### PR TITLE
Update chart.component.js

### DIFF
--- a/www/ftui/components/chart/chart.component.js
+++ b/www/ftui/components/chart/chart.component.js
@@ -11,7 +11,7 @@ import { FtuiElement } from '../element.component.js';
 import { FtuiChartData } from './chart-data.component.js';
 import { fhemService } from '../../modules/ftui/fhem.service.js';
 import { Chart } from '../../modules/chart.js/chart.min.js';
-import { dateFormat, getStylePropertyValue } from '../../modules/ftui/ftui.helper.js';
+import { dateFormat, getStylePropertyValue, isVisible } from '../../modules/ftui/ftui.helper.js';
 import '../../modules/chart.js/chartjs-adapter-date-fns.bundle.min.js';
 
 const HOUR = 3600 * 1000;
@@ -322,6 +322,9 @@ export class FtuiChart extends FtuiElement {
   }
 
   refresh() {
+    if (!(isVisible(this))) {
+      return;
+    }
     this.updateControls();
 
     this.dataElements.forEach(dataElement => {


### PR DESCRIPTION
Only Update if Visible
Optimizes the loading time
The loading time on my surface is reduced from approx. 1.5 minutes to 30 seconds.

I think the loading time can be significantly reduced if the chart data is only loaded when it is visible.